### PR TITLE
SRE-2267 use service account

### DIFF
--- a/charts/gha-runner-deployment/templates/runner-deployment.yaml
+++ b/charts/gha-runner-deployment/templates/runner-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "gha-runner-deployment.labels" . | nindent 4}}
 spec:
   replicas: {{ .Values.replicaCount }}
+  serviceAccountName: {{ .Values.serviceAccount.name }}
   template:
     {{- with .Values.runnerDeployment.metadata }}
     metadata:


### PR DESCRIPTION
Attach service account to RunnerDeployment to use role that allow pod creation.