### PR TITLE
FIX: Allow runner pod eviction

### DIFF
--- a/charts/gha-runner-deployment/Chart.yaml
+++ b/charts/gha-runner-deployment/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gha-runner-deployment
 description: A Helm chart for Github Action Runner Deployments
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 keywords:
   - Github Action Runner Deployment
 maintainers:

--- a/charts/gha-runner-deployment/values.yaml
+++ b/charts/gha-runner-deployment/values.yaml
@@ -86,7 +86,9 @@ tolerations: []
 affinity: {}
 
 runnerDeployment:
-  metadata: {}
+  metadata:
+    labels:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   #   pass labels, annotations, name, and annotations
   #   annotations:
   #     kubectl.kubernetes.io/default-logs-container: "runner"


### PR DESCRIPTION
The cluster-autoscaler currently [doesn't like to reschedule](https://grafana.prod.tatari.dev/explore?orgId=1&panes=%7B%22yVe%22:%7B%22datasource%22:%22loki%22,%22queries%22:%5B%7B%22expr%22:%22%7Bnamespace%3D%5C%22kube-system%5C%22,app%3D%5C%22aws-cluster-autoscaler%5C%22,container%3D%5C%22aws-cluster-autoscaler%5C%22%7D%7C%3D%5C%22is%20not%20replicated%5C%22%22,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22loki%22%7D,%22editorMode%22:%22code%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-12h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1) these pods as it doesn't know the lineage from a standard deployment. This label should fix that.

This should be the right [format](https://github.com/actions/actions-runner-controller/blob/master/docs/deploying-arc-runners.md).

```shell
$ helm template prod -f values.yaml --include-crds . --dry-run |grep -A30 'kind: RunnerDeployment'
kind: RunnerDeployment
metadata:
  name: prod-gha-runner-deployment
  namespace: prod-gha-runner-deployment
  labels:
    helm.sh/chart: gha-runner-deployment-0.3.1
    app.kubernetes.io/name: gha-runner-deployment
    app.kubernetes.io/instance: prod
    app.kubernetes.io/version: "0.3.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  template:
    metadata:
      labels:
        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
```
