### PR TITLE
SRE-2455 / Using rewrite to remove env from secrets path

### DIFF
--- a/charts/secretstores/Chart.yaml
+++ b/charts/secretstores/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: secretstores
 description: A Helm chart to create namespaced ExternalSecrets SecretStores
 type: application
-version: 0.0.2
-appVersion: "0.0.2"
+version: 0.0.3
+appVersion: "0.0.3"
 keywords:
   - External Secrets Namespaced Store
 maintainers:

--- a/charts/secretstores/templates/externalsecret.yaml
+++ b/charts/secretstores/templates/externalsecret.yaml
@@ -27,10 +27,18 @@ spec:
         path: "{{$.Values.global.env}}/{{include "secretstores.fullname" $}}"
         name:
           regexp: ".*"
+      rewrite:
+        - regexp:
+          source: "{{$.Values.global.env}}/(.*)"
+          target: "$1"
     - find:
         path: "{{$.Values.global.env}}/shared"
         name:
           regexp: ".*"
+      rewrite:
+        - regexp:
+          source: "{{$.Values.global.env}}/(.*)"
+          target: "$1"
     - find:
         path: "shared"
         name:


### PR DESCRIPTION
JIRA SRE-2455

## Summary
Removing environment name from secret path (k8s key) to make variable creation easier.

## Testing
Templated locally successfully.  Will ensure some-testserver can pull the correct names.