### PR TITLE
SRE-2455 / Replacing bad chars and fixing indents

### DIFF
--- a/charts/secretstores/Chart.yaml
+++ b/charts/secretstores/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: secretstores
 description: A Helm chart to create namespaced ExternalSecrets SecretStores
 type: application
-version: 0.0.3
-appVersion: "0.0.3"
+version: 0.0.4
+appVersion: "0.0.4"
 keywords:
   - External Secrets Namespaced Store
 maintainers:

--- a/charts/secretstores/templates/externalsecret.yaml
+++ b/charts/secretstores/templates/externalsecret.yaml
@@ -29,16 +29,22 @@ spec:
           regexp: ".*"
       rewrite:
         - regexp:
-          source: "{{$.Values.global.env}}/(.*)"
-          target: "$1"
+            source: "{{$.Values.global.env}}/(.*)"
+            target: "$1"
+        - regexp:
+            source: "/"
+            target: "_"
     - find:
         path: "{{$.Values.global.env}}/shared"
         name:
           regexp: ".*"
       rewrite:
         - regexp:
-          source: "{{$.Values.global.env}}/(.*)"
-          target: "$1"
+            source: "{{$.Values.global.env}}/(.*)"
+            target: "$1"
+        - regexp:
+            source: "/"
+            target: "_"
     - find:
         path: "shared"
         name:


### PR DESCRIPTION
JIRA SRE-2455

## Summary
Fixing secret rewrite syntax and replacing "/" with "_" for k8s secret keys.

## Testing
Deployed changes to [test/some-testserver](https://argocd.test.tatari.dev/applications/argocd/test-some-testserver?view=tree&resource=) and works well.